### PR TITLE
Frameless widget

### DIFF
--- a/src/scripts/provider.js
+++ b/src/scripts/provider.js
@@ -67,6 +67,7 @@ angular.module('adf.provider', [])
     *      if passed as a string.
     *   - `controllerAs` - `{string=}` - A controller alias name. If present the controller will be
     *      published to scope under the `controllerAs` name.
+    *   - `frameless` - `{boolean=}` - false if the widget should be shown in frameless mode. The default is false.
     *   - `template` - `{string=|function()=}` - html template as a string.
     *   - `templateUrl` - `{string=}` - path to an html template.
     *   - `reload` - `{boolean=}` - true if the widget could be reloaded. The default is false.
@@ -94,7 +95,7 @@ angular.module('adf.provider', [])
     * @returns {Object} self
     */
     this.widget = function(name, widget){
-      var w = angular.extend({reload: false}, widget);
+      var w = angular.extend({reload: false, frameless: false}, widget);
       if ( w.edit ){
         var edit = {reload: true};
         angular.extend(edit, w.edit);

--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -41,6 +41,10 @@ angular.module('adf')
             definition.titleTemplateUrl = adfTemplatePath + 'widget-title.html';
           }
 
+          if (!definition.titleTemplateUrl) {
+            definition.frameless = w.frameless;
+          }
+
           // set id for sortable
           if (!definition.wid) {
             definition.wid = dashboard.id();

--- a/src/templates/widget.html
+++ b/src/templates/widget.html
@@ -1,8 +1,8 @@
-<div adf-id="{{definition.wid}}" adf-widget-type="{{definition.type}}" class="widget panel panel-default">
-  <div class="panel-heading clearfix">
+<div adf-id="{{definition.wid}}" adf-widget-type="{{definition.type}}" ng-class="{'panel panel-default':!widget.frameless || editMode}" class="widget">
+  <div class="panel-heading clearfix" ng-if="!widget.frameless || editMode">
   <div ng-include src="definition.titleTemplateUrl"></div>
   </div>
-  <div class="panel-body" collapse="widgetState.isCollapsed">
+  <div ng-class="{'panel-body':!widget.frameless || editMode}" collapse="widgetState.isCollapsed">
     <adf-widget-content model="definition" content="widget" />
   </div>
 </div>


### PR DESCRIPTION
Added possibility to remove frame that's around widget, but only in normal mode - in edit mode frame appers.

This solution allows creation of completely custom widgets without white frame around them (previous enforced by adf).

To create widget in a frameless mode just pass the object with true value set in frameless field  as a second parameter of the dashboardProvider.widget method.
